### PR TITLE
Fix CREATE2 opcode

### DIFF
--- a/execution/evm/asm/opcodes.go
+++ b/execution/evm/asm/opcodes.go
@@ -174,10 +174,10 @@ const (
 	CALLCODE
 	RETURN
 	DELEGATECALL
+	CREATE2
 
 	// 0x70 range - other
 	STATICCALL   = 0xfa
-	CREATE2      = 0xfb
 	REVERT       = 0xfd
 	INVALID      = 0xfe
 	SELFDESTRUCT = 0xff
@@ -336,9 +336,9 @@ var opCodeNames = map[OpCode]string{
 	RETURN:       "RETURN",
 	CALLCODE:     "CALLCODE",
 	DELEGATECALL: "DELEGATECALL",
+	CREATE2:      "CREATE2",
 	STATICCALL:   "STATICCALL",
 	// 0x70 range - other
-	CREATE2:      "CREATE2",
 	REVERT:       "REVERT",
 	INVALID:      "INVALID",
 	SELFDESTRUCT: "SELFDESTRUCT",


### PR DESCRIPTION
Set CREATE2 opcode value to 0xF5 as described in official doc https://github.com/crytic/evm-opcodes#table